### PR TITLE
Get rid of build warnings

### DIFF
--- a/bridge.cpp
+++ b/bridge.cpp
@@ -140,7 +140,7 @@ Bridge::~Bridge()
   delete mem;
 }
 
-void Bridge::user(char *str, ...)
+void Bridge::user(const char *str, ...)
 {
   va_list va;
   va_start(va, str);
@@ -148,7 +148,7 @@ void Bridge::user(char *str, ...)
   va_end(va);
 }
 
-void Bridge::debug(char *str, ...)
+void Bridge::debug(const char *str, ...)
 {
   va_list va;
   va_start(va, str);

--- a/bridge.h
+++ b/bridge.h
@@ -21,8 +21,8 @@ class Bridge : public LogIF {
     ~Bridge();
     void mainLoop();
 
-    void user(char *str, ...);
-    void debug(char *str, ...);
+    void user(const char *str, ...);
+    void debug(const char *str, ...);
 
   private:
   MemIF* mem;

--- a/log.h
+++ b/log.h
@@ -3,8 +3,8 @@
 
 class LogIF {
   public:
-    virtual void user(char *str, ...) = 0;
-    virtual void debug(char *str, ...) = 0;
+    virtual void user(const char *str, ...) = 0;
+    virtual void debug(const char *str, ...) = 0;
 };
 
 #endif

--- a/rsp.cpp
+++ b/rsp.cpp
@@ -978,7 +978,7 @@ Rsp::mem_write_ascii(char* data, size_t len) {
   char* buffer;
   int buffer_len;
 
-  if (sscanf(data, "%x,%d:", &addr, &length) != 2) {
+  if (sscanf(data, "%x,%ld:", &addr, &length) != 2) {
     fprintf(stderr, "Could not parse packet\n");
     return false;
   }
@@ -1038,7 +1038,7 @@ Rsp::mem_write(char* data, size_t len) {
   char* buffer;
   int buffer_len;
 
-  if (sscanf(data, "%x,%x:", &addr, &length) != 2) {
+  if (sscanf(data, "%x,%lx:", &addr, &length) != 2) {
     fprintf(stderr, "Could not parse packet\n");
     return false;
   }


### PR DESCRIPTION
This version of debug_bridge has some nasty looking but perhaps harmless warnings. This patch gets rid of those.