### PR TITLE
Fix wrong conversion specifier in mem_write

### DIFF
--- a/debug_if.cpp
+++ b/debug_if.cpp
@@ -37,7 +37,7 @@ bool
 DbgIF::halt() {
   uint32_t data;
   if (!this->read(DBG_CTRL_REG, &data)) {
-    fprintf(stderr, "debug_is_stopped: Reading from CTRL reg failed\n");
+    fprintf(stderr, "debug_halt: Reading from CTRL reg failed\n");
     return false;
   }
 

--- a/mem_zynq_spi.cpp
+++ b/mem_zynq_spi.cpp
@@ -82,18 +82,20 @@ FpgaIF::mem_read(uint32_t addr, uint32_t *rdata) {
   wr_buf[2] = addr >> 16;
   wr_buf[3] = addr >> 8;
   wr_buf[4] = addr;
+  // wr_buf[5-8] == dummy
 
-  // check if write was sucessful
+  // Commit transfer to kernel and check for errors
   if (ioctl(g_spi_fd, SPI_IOC_MESSAGE(1), transfer) < 0) {
     perror("SPI_IOC_MESSAGE");
     return false;
   }
 
-  // shift everything by one bit
+  // shift everything read by one bit. FIXME: wtf? timing problem?
   for(unsigned int i = 0; i < transfer->len-1; i++) {
     rd_buf[i] = (rd_buf[i] << 1) | ((rd_buf[i+1] & 0x80) >> 7);
   }
 
+  // Convert actual memory data to right endian
   *rdata = htonl(*((int*)&rd_buf[9]));
 
   return true;

--- a/rsp.cpp
+++ b/rsp.cpp
@@ -938,7 +938,9 @@ Rsp::waitStop(DbgIF* dbgif) {
       ret = recv(m_socket_client, &pkt, 1, 0);
       if (ret == 1 && pkt == 0x3) {
         if (dbgif) {
-          dbgif->halt();
+          if (!dbgif->halt()) {
+            printf("ERROR: failed sending halt\n");
+          }
 
           if (!dbgif->is_stopped()) {
             printf("ERROR: failed to stop core\n");

--- a/rsp.cpp
+++ b/rsp.cpp
@@ -1058,13 +1058,6 @@ Rsp::resumeCores() {
   }
 }
 
-void
-Rsp::resumeAll(bool step) {  
-  for (std::list<DbgIF*>::iterator it = m_dbgifs.begin(); it != m_dbgifs.end(); it++) {
-    resumeCore(*it, step);
-  }
-}
-
 bool
 Rsp::resume(bool step) {
   if (m_dbgifs.size() == 1) {

--- a/rsp.cpp
+++ b/rsp.cpp
@@ -382,8 +382,8 @@ Rsp::reset(bool halt) {
       return this->send_str("E00");
       // FIXME: the following does not really work, neither does simply 
       // not re-enabling the fetch enable
-      DbgIF* dbgif = this->get_dbgif(m_thread_sel);
-      dbgif->write(DBG_IE_REG, 0xFFFF);
+      // DbgIF* dbgif = this->get_dbgif(m_thread_sel);
+      // dbgif->write(DBG_IE_REG, 0xFFFF);
     }
 
     return this->send_str("OK");

--- a/rsp.cpp
+++ b/rsp.cpp
@@ -1124,7 +1124,7 @@ Rsp::mem_write_ascii(char* data, size_t len) {
   char* buffer;
   int buffer_len;
 
-  if (sscanf(data, "%" SCNx32 ",%zd:", &addr, &length) != 2) {
+  if (sscanf(data, "%" SCNx32 ",%zu:", &addr, &length) != 2) {
     fprintf(stderr, "Could not parse packet\n");
     return false;
   }
@@ -1180,7 +1180,7 @@ Rsp::mem_write(char* data, size_t len) {
   size_t length;
   unsigned int i;
 
-  if (sscanf(data, "%" SCNx32 ",%zd:", &addr, &length) != 2) {
+  if (sscanf(data, "%" SCNx32 ",%zx:", &addr, &length) != 2) {
     fprintf(stderr, "Could not parse packet\n");
     return false;
   }
@@ -1276,7 +1276,7 @@ Rsp::encode_hex(const char *in, char *out, size_t out_len) {
   // This check guarantees that for every non-\0 character in the input 
   // there are two bytes available in the out buffer + one for trailing \0.
   if (2*in_len - 1 > out_len) {
-    fprintf(stderr, "%s: output buffer too small (need %zd, have %zd)\n", 
+    fprintf(stderr, "%s: output buffer too small (need %zu, have %zu)\n", 
       __func__, 2*in_len - 1, out_len);
     return false;
   }

--- a/rsp.h
+++ b/rsp.h
@@ -56,7 +56,6 @@ class Rsp {
     bool waitStop(DbgIF* dbgif);
     bool resume(bool step);
     bool resume(int tid, bool step);
-    void resumeAll(bool step);
     void resumeCore(DbgIF* dbgif, bool step);
     void resumeCoresPrepare(DbgIF *dbgif, bool step);
     void resumeCores();


### PR DESCRIPTION
The value sent by gdb are _hexa_decimal of course.
The wrong specifier was introduced by myself in 21eb86c7.