### PR TITLE
Fix single stepping and signaling of stop reasons

### DIFF
--- a/debug_if.h
+++ b/debug_if.h
@@ -15,8 +15,6 @@
 #define DBG_NPC_REG   0x2000
 #define DBG_PPC_REG   0x2004
 
-#define DBG_CAUSE_BP  0x3
-
 class DbgIF {
   public:
     DbgIF(MemIF* mem, unsigned int base_addr, LogIF *log);

--- a/rsp.cpp
+++ b/rsp.cpp
@@ -668,7 +668,8 @@ Rsp::get_packet(char* pkt, size_t* p_pkt_len) {
     ret = recv(m_socket_client, &c, 1, 0);
 
     if((ret == -1 && errno != EWOULDBLOCK) || (ret == 0)) {
-      fprintf(stderr, "RSP: Error receiving\n");
+      fprintf(stderr, "RSP: Error receiving start bit: %s\n",
+              ret == 0 ? "Connection reset by peer" : strerror(errno));
       return false;
     }
 
@@ -697,7 +698,8 @@ Rsp::get_packet(char* pkt, size_t* p_pkt_len) {
     ret = recv(m_socket_client, &c, 1, 0);
 
     if((ret == -1 && errno != EWOULDBLOCK) || (ret == 0)) {
-      fprintf(stderr, "RSP: Error receiving\n");
+      fprintf(stderr, "RSP: Error receiving payload: %s\n",
+              ret == 0 ? "Connection reset by peer" : strerror(errno));
       return false;
     }
 
@@ -728,13 +730,15 @@ Rsp::get_packet(char* pkt, size_t* p_pkt_len) {
   // checksum, 2 bytes
   ret = recv(m_socket_client, &check_chars[0], 1, 0);
   if((ret == -1 && errno != EWOULDBLOCK) || (ret == 0)) {
-    fprintf(stderr, "RSP: Error receiving\n");
+    fprintf(stderr, "RSP: Error receiving checksum[0]: %s\n",
+            ret == 0 ? "Connection reset by peer" : strerror(errno));
     return false;
   }
 
   ret = recv(m_socket_client, &check_chars[1], 1, 0);
   if((ret == -1 && errno != EWOULDBLOCK) || (ret == 0)) {
-    fprintf(stderr, "RSP: Error receiving\n");
+    fprintf(stderr, "RSP: Error receiving checksum[1]: %s\n",
+            ret == 0 ? "Connection reset by peer" : strerror(errno));
     return false;
   }
 

--- a/rsp.cpp
+++ b/rsp.cpp
@@ -45,6 +45,7 @@ bool
 Rsp::open() {
   struct sockaddr_in addr;
   int yes = 1;
+  bool ret = 0;
 
   addr.sin_family = AF_INET;
   addr.sin_port = htons(m_socket_port);
@@ -77,10 +78,13 @@ Rsp::open() {
 
   // now clear resources
   for (std::list<DbgIF*>::iterator it = m_dbgifs.begin(); it != m_dbgifs.end(); it++) {
-    (*it)->halt();
+    if (!(*it)->halt()) {
+      printf("ERROR: failed sending halt\n");
+      ret = 1;
+    }
   }
 
-  return true;
+  return ret;
 }
 
 void
@@ -950,7 +954,9 @@ Rsp::waitStop(DbgIF* dbgif) {
           return this->signal();
         } else {          
           for (std::list<DbgIF*>::iterator it = m_dbgifs.begin(); it != m_dbgifs.end(); it++) {
-            (*it)->halt();
+            if (!(*it)->halt()) {
+              printf("ERROR: failed sending halt\n");
+            }
 
             if (!(*it)->is_stopped()) {
               printf("ERROR: failed to stop core\n");

--- a/rsp.h
+++ b/rsp.h
@@ -29,6 +29,22 @@ class Rsp {
     bool loop();
 
   private:
+    enum target_signal {
+      TARGET_SIGNAL_NONE =  0,
+      TARGET_SIGNAL_INT  =  2,
+      TARGET_SIGNAL_ILL  =  4,
+      TARGET_SIGNAL_TRAP =  5,
+      TARGET_SIGNAL_FPE  =  8,
+      TARGET_SIGNAL_BUS  = 10,
+      TARGET_SIGNAL_SEGV = 11,
+      TARGET_SIGNAL_ALRM = 14,
+      TARGET_SIGNAL_STOP = 17,
+      TARGET_SIGNAL_USR2 = 31,
+      TARGET_SIGNAL_PWR  = 32,
+
+      TARGET_SIGNAL_LAST,
+    };
+
     bool decode(char* data, size_t len);
 
     bool multithread(char* data, size_t len);
@@ -39,6 +55,7 @@ class Rsp {
     bool query(char* data, size_t len);
     bool monitor(char* data, size_t len);
     bool v_packet(char* data, size_t len);
+    bool ctrlc(void); // break, reserved keyword, thus not used as function name
 
     bool regs_send();
     bool reg_read(char* data, size_t len);
@@ -46,9 +63,10 @@ class Rsp {
 
     bool get_packet(char* data, size_t* len);
 
-    bool signal();
 
     bool send(const char* data, size_t len);
+    bool send_stop_reason();
+    bool send_signal(enum target_signal signal);
     bool send_str(const char* data);
     // internal helper functions
     bool pc_read(unsigned int* pc);


### PR DESCRIPTION
Hi @haugoug,
you were an hour too early with the merge ;)
I was working on fixing a major problem over the weekend: single stepping and the ID mapping of signals sent back to GDB were completely wrong - probably to the [lousy documentation](https://github.com/pulp-platform/riscv/issues/69) of the `DBG_CAUSE` register.

I have not tested these changes with interrupts or anything but ordinary breakpoints but it is pretty clear that this is a huge improvement. One could even say that debugging worked only by accident in the past :)